### PR TITLE
Remove git command from Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,14 +1,2 @@
 import Distribution.Simple
-import Distribution.Verbosity
-import Distribution.Simple.Utils
-
-prepareBuild =
-    rawSystemExit normal "git" ["submodule", "update", "--init", "--recursive"]
-
-main =
-    defaultMainWithHooks simpleUserHooks
-    { preBuild = \args buildFlags ->
-          do
-              prepareBuild
-              preBuild simpleUserHooks args buildFlags
-    }
+main = defaultMain

--- a/bindings-freetype-gl.cabal
+++ b/bindings-freetype-gl.cabal
@@ -10,7 +10,7 @@ author:              Eyal Lotem
 maintainer:          eyal.lotem@gmail.com
 copyright:           2016 Eyal Lotem
 category:            Graphics, Fonts, Bindings
-build-type:          Custom
+build-type:          Simple
 extra-source-files:  windows/glew.c
                      windows/GL/glew.h
                      windows/GL/wglew.h
@@ -25,11 +25,6 @@ extra-source-files:  windows/glew.c
                      freetype-gl/vector.h
                      freetype-gl/vertex-attribute.h
                      freetype-gl/vertex-buffer.h
-
-custom-setup
-  setup-depends:
-                 base  >= 4.5
-               , Cabal >= 2.2
 
 library
   exposed-modules:     Bindings.FreetypeGL.FontManager


### PR DESCRIPTION
Without this the build fails when using nix as the `.git` folder is removed before building. This is because Nix automatically prepares all of the source with pre-determined commit refs, including submodules. :)

Also it adds `git` as an implicit build dependency for this module, which isn't really correct. 